### PR TITLE
Faster version of shadow_df(). Removes chained type conversions, appr…

### DIFF
--- a/R/shadow_df.R
+++ b/R/shadow_df.R
@@ -8,9 +8,15 @@
 #'
 #' @export
 
-shadow_df <- function(x){
-  x %>%
-    is.na.data.frame %>%
-    as.data.frame %>%
-    as_data_frame
+shadow_df <- function (x)
+{
+  y <- if (length(x)) {
+    as_data_frame(
+      lapply(x, "is.na")
+    )
+  }
+  else data_frame()
+  y
 }
+
+


### PR DESCRIPTION
I wrote you a new shadow_df() based on is.na.data.frame(), removes chained type conversions and speeds up execution. See:

```R
shadow_df <- function (x)
{
  y <- if (length(x)) {
    as_data_frame(
      lapply(x, "is.na")
    )
  }
  else data_frame()
  y
}


old_shadow_df <- function(x){
  x %>%
    is.na.data.frame %>%
    as.data.frame %>%
    as_data_frame
}

library(microbenchmark)
microbenchmark(old_shadow_df(df), shadow_df(df))
```

Also this is my first pull request so... I have no idea what I'm doing. :)